### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# 🎧 Awesome Self-Hosted Music
+# ð§ Awesome Self-Hosted Music
 
 > A curated and structured collection of tools, servers, clients, plugins, themes, integrations, and deployment guides for the **self-hosted music ecosystem**.
 
 ---
 
-## 📚 Table of Contents
+## ð Table of Contents
 
-- [🎧 Awesome Self-Hosted Music](#-awesome-self-hosted-music)
-  - [📚 Table of Contents](#-table-of-contents)
-  - [📖 About](#-about)
-  - [🖥️ Servers](#️-servers)
-  - [📱 Music Players](#-music-players)
+- [ð§ Awesome Self-Hosted Music](#-awesome-self-hosted-music)
+  - [ð Table of Contents](#-table-of-contents)
+  - [ð About](#-about)
+  - [ð¥ï¸ Servers](#ï¸-servers)
+  - [ð± Music Players](#-music-players)
       - [Clients for Servers](#clients-for-servers)
       - [Local Players](#local-players)
-  - [🔌 Plugins \& Extensions](#-plugins--extensions)
-  - [📊 Scrobblers](#-scrobblers)
+  - [ð Plugins \& Extensions](#-plugins--extensions)
+  - [ð Scrobblers](#-scrobblers)
       - [Supported Services](#supported-services)
-  - [🎨 Themes](#-themes)
-  - [🐳 Deployment](#-deployment)
-  - [🔗 Integrations](#-integrations)
-  - [🛠️ Tools](#️-tools)
-  - [🤝 Contributing](#-contributing)
-  - [📜 License](#-license)
+  - [ð¨ Themes](#-themes)
+  - [ð³ Deployment](#-deployment)
+  - [ð Integrations](#-integrations)
+  - [ð ï¸ Tools](#ï¸-tools)
+  - [ð¤ Contributing](#-contributing)
+  - [ð License](#-license)
 
 ---
 
-## 📖 About
+## ð About
 
 Self-hosted music platforms allow you to build your own personal streaming service using your own library and infrastructure.
 
@@ -33,15 +33,15 @@ This repository aims to centralize useful resources for people who host their ow
 
 ---
 
-## 🖥️ Servers
+## ð¥ï¸ Servers
 
 > Platforms that host and stream your music library.
 
-See → [Servers/README.md](Servers/README.md)
+See â [Servers/README.md](Servers/README.md)
 
 ---
 
-## 📱 Music Players
+## ð± Music Players
 
 > Music players and applications compatible with self-hosted music servers.
 
@@ -49,70 +49,70 @@ See → [Servers/README.md](Servers/README.md)
 
 Applications designed to connect to and stream from self-hosted servers.
 
-See → [Servers-Clients/README.md](Servers-Clients/README.md)
+See â [Servers-Clients/README.md](Servers-Clients/README.md)
 
 #### Local Players
 
 Standalone players for locally stored libraries.
 
-See → [Local-Players/README.md](Local-Players/README.md)
+See â [Local-Players/README.md](Local-Players/README.md)
 
 ---
 
-## 🔌 Plugins & Extensions
+## ð Plugins & Extensions
 
 > Unofficial plugins, API-based extensions, and enhancement tools.
 
-See → [plugins/README.md](plugins/README.md)
+See â [plugins/README.md](plugins/README.md)
 
 ---
 
-## 📊 Scrobblers
+## ð Scrobblers
 
 > Guides for tracking your listening history using scrobbling services.
 
 #### Supported Services
 
-- **Last.fm** — Track and share your listening history
-- **ListenBrainz** — Open-source listening history tracking
+- **Last.fm** â Track and share your listening history
+- **ListenBrainz** â Open-source listening history tracking
 
-See → [scrobblers/README.md](scrobblers/README.md)
+See â [scrobblers/README.md](scrobblers/README.md)
 
 ---
 
-## 🎨 Themes
+## ð¨ Themes
 
 > Custom themes and UI modifications for self-hosted music platforms.
 
-See → [themes/README.md](themes/README.md)
+See â [themes/README.md](themes/README.md)
 
 ---
 
-## 🐳 Deployment
+## ð³ Deployment
 
 > Infrastructure and hosting guides for setting up your own instance.
 
-See → [deployment/README.md](deployment/README.md)
+See â [deployment/README.md](deployment/README.md)
 
 ---
 
-## 🔗 Integrations
+## ð Integrations
 
 > External services and connected platform guides.
 
-See → [integration/README.md](integration/README.md)
+See â [integration/README.md](integration/README.md)
 
 ---
 
-## 🛠️ Tools
+## ð ï¸ Tools
 
 > Complementary tools for managing and enhancing your music library.
 
-See → [tools/README.md](tools/README.md)
+See â [tools/README.md](tools/README.md)
 
 ---
 
-## 🤝 Contributing
+## ð¤ Contributing
 
 Contributions are welcome!
 Feel free to open issues or submit pull requests to improve this repository.
@@ -121,7 +121,9 @@ Please ensure your additions follow the existing structure and include relevant 
 
 ---
 
-## 📜 License
+## ð License
 
 This project is licensed under the **LGPL-3.0** License.
 See the [LICENSE](LICENSE) file for details.
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because it is a practical tool for content creators and developers working with video processing.